### PR TITLE
Underline 6 and 9 on both volvelle wheels

### DIFF
--- a/SSS32.ps
+++ b/SSS32.ps
@@ -185,7 +185,13 @@
    [ exch 1 exch dup { 32 idiv exch } forall 0 exch { 31 and } forall ] polymod0
  } bind def
 
-/centreshow {dup stringwidth pop 2 div neg 0 rmoveto show} bind def
+/underlineshow {
+    dup dup (6) eq exch (9) eq or { % if the string is (6) or (9)
+        gsave (_) show grestore % draw an underline
+    } if
+    show
+} bind def
+/centreshow {dup stringwidth pop 2 div neg 0 rmoveto underlineshow} bind def
 /centresquare {dup neg 2 div dup rmoveto dup 0 rlineto dup 0 exch rlineto neg 0 rlineto closepath stroke} bind def
 /concatstrings % (a) (b) -> (ab)
    { exch dup length
@@ -329,7 +335,7 @@ end
        -26 -3 rmoveto % Move to the left
        31 exch sub % 31 - loop index
        permV exch get code exch 1 getinterval % Permute index and extract 1-char substring of alphabet
-       /Courier findfont 12 scalefont setfont show % ...and draw it
+       /Courier findfont 12 scalefont setfont underlineshow % ...and draw it
        (\256) /Symbol findfont 12 scalefont setfont show % Draw a right arrow
    } for
    showpage


### PR DESCRIPTION
Builds on #14 but is a separate PR because there's more room for bikeshedding (e.g. should we underline other characters? all the characters? try a different approach)

Fixes #12 