### PR TITLE
split checksum table across two pages

### DIFF
--- a/SSS32.ps
+++ b/SSS32.ps
@@ -1041,14 +1041,9 @@ page exch perm 3 index get exch  makeShare code exch get glyphshow
   } for
 
   % Draw vertical background lines: one double-wide black one per column
+  0 setgray
   x y moveto
   0 1 7 {
-    1 setgray
-    gsave
-      0 tHeight neg rlineto
-      cellW 26 div neg 0 rlineto 0 tHeight rlineto closepath fill
-    grestore
-    0 setgray
     gsave
       0 tHeight neg rlineto
       cellW 2 mul 13 div 0 rlineto 0 tHeight rlineto closepath fill
@@ -1873,6 +1868,7 @@ pgsize aload pop 72 sub exch 108 sub 2 div
 24 drawChecksumTable
 
 pgsave restore
+showpage
 
 %%Page: 25 25
 %%PageOrientation: Landscape

--- a/SSS32.ps
+++ b/SSS32.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Orientation: Portrait
-%%Pages: 24
+%%Pages: 25
 %%EndComments
 %%BeginSetup
 [(Shamir's Secret) (Sharing Codex)]
@@ -1013,6 +1013,86 @@ page exch perm 3 index get exch  makeShare code exch get glyphshow
 } bind def
 
 %******************
+%* Checksum Table
+%*
+%* Draws the giant lookup table used by the checksum worksheet
+%*
+
+/drawChecksumTable {
+  10 dict begin
+  { /startVal /tHeight /tWidth /y /x } {exch def} forall
+
+  /cellH tHeight 32 div def
+  /cellW tWidth 8 div def
+
+  % Draw horizontal background lines: one black one for the heading then
+  % alternating 4-cell-height white/gray for the content background
+  x y moveto
+  0 1 31 {
+    dup 0 eq { 0.808 0.923 0.953 } {
+      8 mod 4 lt { 0.808 0.923 0.953 } { 1 1 1 } ifelse
+    } ifelse setrgbcolor
+
+    gsave
+      tWidth 0 rlineto
+      0 cellH neg rlineto tWidth neg 0 rlineto closepath fill
+    grestore
+    0 cellH neg rmoveto
+  } for
+
+  % Draw vertical background lines: one double-wide black one per column
+  x y moveto
+  0 1 7 {
+    1 setgray
+    gsave
+      0 tHeight neg rlineto
+      cellW 26 div neg 0 rlineto 0 tHeight rlineto closepath fill
+    grestore
+    0 setgray
+    gsave
+      0 tHeight neg rlineto
+      cellW 2 mul 13 div 0 rlineto 0 tHeight rlineto closepath fill
+    grestore
+    cellW 0 rmoveto
+  } for
+
+  % Draw content
+  startVal 1 startVal 7 add {
+    /xVal exch def
+    x xVal startVal sub cellW mul add 2 add y 1.5 add moveto
+    0 1 31 {
+      /yVal exch def
+      0 cellH neg rmoveto
+
+      gsave
+        /Courier-Bold findfont 8.5 scalefont setfont
+        1 setgray
+        code perm xVal get get glyphshow
+        code perm yVal get get glyphshow
+      grestore
+
+      gsave
+        cellW 2 mul 13 div 0 rmoveto
+        perm xVal get perm yVal get polymodshift2 {
+          code exch get glyphshow
+          0.25 0 rmoveto
+        } forall
+      grestore
+    } for
+  } for
+
+  % Bounding box
+  0.5 setlinewidth
+  x y moveto
+  0 tHeight neg rlineto
+  tWidth 0 rlineto
+  0 tHeight rlineto
+  closepath stroke
+
+  end
+} bind def
+
+%******************
 %* Checksum Worksheet
 %*
 %* Functionality for the checksum, addition, bit conversion, etc., worksheets,
@@ -1749,37 +1829,52 @@ end
 pgsave restore
 showpage
 %%Page: 23 23
+%%PageOrientation: Landscape
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
-/Helvetica-Bold findfont 10 scalefont setfont
-pgsize aload pop 40 sub exch 2 div exch
-moveto (ms32 Checksum Table) centreshow
+90 rotate 0 -750 translate
 
-0 1 31 {
-0 1 31 {
-2 copy 730 exch 7 mul sub 1 index 11 idiv 240 mul sub exch 11 mod 50 mul 30 add exch moveto
-2 copy
-perm exch get exch perm exch get exch
-2 copy
-code exch get exch code exch get exch
-/Courier-Bold findfont polymodulus length 6 le {8} {4.5} ifelse scalefont setfont
-exch glyphshow glyphshow
-/Courier findfont polymodulus length 6 le {8} {4.5} ifelse scalefont setfont
-3 0 rmoveto
-polymodulus length array
-3 1 roll
-polymodshift2 0 1 polymodulus length 1 sub { 3 copy get code exch get 3 2 roll exch put } for
-pop
-{glyphshow} forall
-pop
-} for
-pop
-} for
+/Helvetica-Bold findfont 10 scalefont setfont
+pgsize aload pop exch pop 2 div 700
+moveto (MS32 Checksum Table) centreshow
+
+
+/Courier findfont 8.5 scalefont setfont
+36 pgsize aload pop exch pop 104 sub
+pgsize aload pop 72 sub exch 108 sub 2 div
+0 drawChecksumTable
+
+36 pgsize aload pop exch pop 2 div 32 add
+pgsize aload pop 72 sub exch 108 sub 2 div
+8 drawChecksumTable
 
 pgsave restore
 showpage
+
 %%Page: 24 24
+%%PageOrientation: Landscape
+%%BeginPageSetup
+/pgsave save def
+%%EndPageSetup
+90 rotate 0 -750 translate
+
+/Helvetica-Bold findfont 10 scalefont setfont
+pgsize aload pop exch pop 2 div 700
+moveto (MS32 Checksum Table) centreshow
+
+/Courier findfont 8.5 scalefont setfont
+36 pgsize aload pop exch pop 104 sub
+pgsize aload pop 72 sub exch 108 sub 2 div
+16 drawChecksumTable
+
+36 pgsize aload pop exch pop 2 div 32 add
+pgsize aload pop 72 sub exch 108 sub 2 div
+24 drawChecksumTable
+
+pgsave restore
+
+%%Page: 25 25
 %%PageOrientation: Landscape
 %%BeginPageSetup
 /pgsave save def

--- a/SSS32.ps
+++ b/SSS32.ps
@@ -1828,22 +1828,27 @@ showpage
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
-90 rotate 0 -750 translate
+90 rotate
+10 dict begin
+pgsize aload pop
+/pageW exch def
+/pageH exch def
+
+0 pageH neg translate
 
 /Helvetica-Bold findfont 10 scalefont setfont
-pgsize aload pop exch pop 2 div 700
-moveto (MS32 Checksum Table) centreshow
-
+pageW 2 div pageH 48 sub moveto (MS32 Checksum Table) centreshow
 
 /Courier findfont 8.5 scalefont setfont
-36 pgsize aload pop exch pop 104 sub
-pgsize aload pop 72 sub exch 108 sub 2 div
+36 pageH 64 sub  % x y
+pageW 64 sub pageH 144 sub 2 div % w h
 0 drawChecksumTable
 
-36 pgsize aload pop exch pop 2 div 32 add
-pgsize aload pop 72 sub exch 108 sub 2 div
+36 pageH 2 div 16 sub % x y
+pageW 64 sub pageH 144 sub 2 div % w h
 8 drawChecksumTable
 
+end
 pgsave restore
 showpage
 
@@ -1852,21 +1857,27 @@ showpage
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
-90 rotate 0 -750 translate
+90 rotate
+10 dict begin
+pgsize aload pop
+/pageW exch def
+/pageH exch def
+
+0 pageH neg translate
 
 /Helvetica-Bold findfont 10 scalefont setfont
-pgsize aload pop exch pop 2 div 700
-moveto (MS32 Checksum Table) centreshow
+pageW 2 div pageH 48 sub moveto (MS32 Checksum Table) centreshow
 
 /Courier findfont 8.5 scalefont setfont
-36 pgsize aload pop exch pop 104 sub
-pgsize aload pop 72 sub exch 108 sub 2 div
+36 pageH 64 sub  % x y
+pageW 64 sub pageH 144 sub 2 div % w h
 16 drawChecksumTable
 
-36 pgsize aload pop exch pop 2 div 32 add
-pgsize aload pop 72 sub exch 108 sub 2 div
+36 pageH 2 div 16 sub % x y
+pageW 64 sub pageH 144 sub 2 div % w h
 24 drawChecksumTable
 
+end
 pgsave restore
 showpage
 


### PR DESCRIPTION
Replace checksum table with a two-page version that uses largely the same style as #27.