### PR TITLE
Clean up page management

### DIFF
--- a/SSS32.ps
+++ b/SSS32.ps
@@ -353,6 +353,61 @@ end
   } ifelse
 def
 
+20 dict dup /portraitPage exch def begin
+  pgsize aload pop [ /pageH /pageW ] { exch def } forall
+  /centerX pageW 2 div def
+  /centerY pageH 2 div def
+  /marginX1 36 def
+  /marginX2 pageW 36 sub def
+  /marginY1 pageH 48 sub def
+  /marginY2 48 def
+  /marginW marginX2 marginX1 sub def
+  /marginH marginY2 marginY1 sub def
+
+  % Draw a line indicating where the margins of the page are; can be used
+  % for debugging graphical output
+  /drawMargin {
+    gsave
+      0 setgray thin line
+      marginX1 marginY1 marginW marginH rectstroke
+    grestore
+  } bind def
+
+  % Draw the page number and any (TODO) content in the page content array
+  % Takes the pagenum as a numeric value
+  /drawPageContent {
+    10 dict begin
+    /pagenum exch def
+    gsave
+      /Times-Roman findfont 12 scalefont setfont
+      centerX marginY2 moveto
+      pagenum pagenum 10 lt { 1 } { 2 } ifelse string cvs show
+    grestore
+    end
+  } bind def
+end
+
+% landscapePage is a modified copy of portraitPage
+portraitPage dup 20 dict copy dup /landscapePage exch def begin
+  pgsize aload pop exch [ /pageH /pageW ] { exch def } forall
+  /centerX pageW 2 div def
+  /centerY pageH 2 div def
+  /marginX1 36 def
+  /marginX2 pageW 36 sub def
+  /marginY1 pageH 48 sub def
+  /marginY2 48 def
+  /marginW marginX2 marginX1 sub def
+  /marginH marginY2 marginY1 sub def
+  /pageW portraitPage /pageH get def
+  /pageH portraitPage /pageW get def
+
+  /drawPageContent {
+    90 rotate
+    0 pageH neg translate
+    portraitPage /drawPageContent get exec
+  } bind def
+end
+
 % line : width --
 /line {
   setlinewidth
@@ -1683,6 +1738,7 @@ end
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
+portraitPage begin
 
 /Times-Roman findfont 48 scalefont setfont
 pgsize aload pop exch 2 div exch 300 sub moveto
@@ -1691,6 +1747,7 @@ title {gsave centreshow grestore 0 -70 rmoveto} forall
 /Times-Roman findfont 16 scalefont setfont
 pgsize aload pop exch 2 div exch 700 sub moveto ver centreshow
 
+end
 pgsave restore
 showpage
 
@@ -1703,14 +1760,18 @@ showpage
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
+portraitPage begin 1 drawPageContent
+
 /Helvetica findfont 6 scalefont setfont
-40 750 moveto
+marginX1 marginY1 16 sub moveto
 MIT {gsave ((c)) search {show pop /copyright glyphshow} if show grestore 0 -8 rmoveto} forall
 /Helvetica findfont 6 scalefont setfont
 warning {gsave show grestore 0 -7 rmoveto} forall
 0 -16 rmoveto
 /Helvetica findfont 8 scalefont setfont
 README {gsave show grestore 0 -10 rmoveto} forall
+
+end
 pgsave restore
 showpage
 
@@ -1722,9 +1783,10 @@ showpage
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
+portraitPage begin 2 drawPageContent
 
 % Set 0 0 to top-center of page
-pgsize aload pop exch 2 div exch 72 sub translate
+centerX marginY1 16 sub translate
 
 % Header/data format
 /Helvetica-Bold findfont 16 scalefont setfont
@@ -1756,6 +1818,7 @@ true drawBech32BinaryTable
 0 -24 translate
 drawSymbolTable
 
+end
 pgsave restore
 showpage
 

--- a/SSS32.ps
+++ b/SSS32.ps
@@ -353,19 +353,6 @@ end
   } ifelse
 def
 
-/marginpath {
-10 dict begin
-  pgsize aload pop
-  /h exch def /w exch def
-  /margin 18 def
-  newpath
-  margin margin moveto
-  w margin sub margin lineto
-  w margin sub h margin sub lineto
-  margin h margin sub lineto
-  closepath
-end } bind def
-
 % line : width --
 /line {
   setlinewidth
@@ -2081,7 +2068,6 @@ showpage
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
-% gsave verythin line marginpath stroke grestore
 recoveryDisc begin
 % Draw assembly diagram
 10 dict begin
@@ -2128,7 +2114,6 @@ showpage
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
-% gsave verythin line marginpath stroke grestore
 % Draw assembly diagram
 gsave
   60 700 translate
@@ -2190,7 +2175,6 @@ showpage
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
-% gsave verythin line marginpath stroke grestore
 % Draw assembly diagram
 gsave
   60 700 translate

--- a/SSS32.ps
+++ b/SSS32.ps
@@ -1,6 +1,6 @@
 %!PS-Adobe-3.0
 %%Orientation: Portrait
-%%Pages: 25
+%%Pages: 21
 %%EndComments
 %%BeginSetup
 [(Shamir's Secret) (Sharing Codex)]
@@ -1899,38 +1899,8 @@ tWidth 44 add tHeight 48 add
 
 pgsave restore
 showpage
-%%Page: 5 5
-%%BeginPageSetup
-/pgsave save def
-%%EndPageSetup
-{ 10 dict begin
-  /in exch def
-  /out exch def
-  16 out [ in out ] lagrange
-  dup 1 eq {pop 0} if % X out trying to recover a share with itself.
-  end
-}
-(Recover Share) code2 code [ 32 permS 1 31 getinterval aload pop ] drawBottomWheelPage
-pgsave restore
-showpage
-%%Page: 6 6
-%%BeginPageSetup
-/pgsave save def
-%%EndPageSetup
-% note 0 and 1 are never used, so they are removed from the wheel.
-gsave
-pgsize aload pop 2 div exch 2 div exch translate
-360 64 div rotate
-16 {
-  newpath 0 6 40 mul moveto 0 28 rlineto stroke
-  360 16 div rotate
-} repeat
-grestore
-{gf32mul} (Translation) code code2 [32 1 1 31 {} for] drawBottomWheelPage
 
-pgsave restore
-showpage
-%%Page: 7 7
+%%Page: 5 5
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -1938,7 +1908,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 8 8
+%%Page: 6 6
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -1946,23 +1916,7 @@ showTopWheelPage
 
 pgsave restore
 showpage
-%%Page: 9 9
-%%BeginPageSetup
-/pgsave save def
-%%EndPageSetup
-showTopWheelPage
-
-pgsave restore
-showpage
-%%Page: 10 10
-%%BeginPageSetup
-/pgsave save def
-%%EndPageSetup
-showTopWheelPage
-
-pgsave restore
-showpage
-%%Page: 11 11
+%%Page: 7 7
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2059,7 +2013,7 @@ end
 
 pgsave restore
 showpage
-%%Page: 12 12
+%%Page: 8 8
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2067,7 +2021,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 13 13
+%%Page: 9 9
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2075,7 +2029,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 14 14
+%%Page: 10 10
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2083,7 +2037,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 15 15
+%%Page: 11 11
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2091,7 +2045,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 16 16
+%%Page: 12 12
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2099,7 +2053,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 17 17
+%%Page: 13 13
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2107,7 +2061,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 18 18
+%%Page: 14 14
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2115,7 +2069,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 19 19
+%%Page: 15 15
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2123,7 +2077,7 @@ showpage
 
 pgsave restore
 showpage
-%%Page: 20 20
+%%Page: 16 16
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2170,7 +2124,7 @@ pgsize aload pop 2 div exch 2 div exch translate
 end
 pgsave restore
 showpage
-%%Page: 21 21
+%%Page: 17 17
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2232,7 +2186,7 @@ end
 
 pgsave restore
 showpage
-%%Page: 22 22
+%%Page: 18 18
 %%BeginPageSetup
 /pgsave save def
 %%EndPageSetup
@@ -2361,7 +2315,7 @@ end
 
 pgsave restore
 showpage
-%%Page: 23 23
+%%Page: 19 19
 %%PageOrientation: Landscape
 %%BeginPageSetup
 /pgsave save def
@@ -2390,7 +2344,7 @@ end
 pgsave restore
 showpage
 
-%%Page: 24 24
+%%Page: 20 20
 %%PageOrientation: Landscape
 %%BeginPageSetup
 /pgsave save def
@@ -2419,7 +2373,7 @@ end
 pgsave restore
 showpage
 
-%%Page: 25 25
+%%Page: 21 21
 %%PageOrientation: Landscape
 %%BeginPageSetup
 /pgsave save def


### PR DESCRIPTION
This replaces the `pgsize` array with a richer structure which has some associated functionality. This gives us:

* Page numbering
* (Hopefully) a universal way to handle portrait/landscape/letter/A4 differences
* Somewhere to hook the generic content rendering that I will introduce in a later PR

The current status of this PR just converts the first couple of pages. Looking for a concept ACK on this approach.